### PR TITLE
Remove api prop

### DIFF
--- a/src/ApiContext.tsx
+++ b/src/ApiContext.tsx
@@ -4,15 +4,20 @@ import { ApiService } from './services/ApiService'
 const ENV_API_URL =
 	process.env.REACT_APP_API_URL || '!!! ENV WAS MISSING URL !!!'
 
-const { Provider, Consumer } = createContext({
+const context = createContext({
 	setApi: (newApi: ApiService) => {},
 	api: new ApiService(),
 })
+const ApiContextConsumer = context.Consumer
 
 const ApiContextProvider: FC<any> = (props: any) => {
 	const [api, setApi] = useState(new ApiService(ENV_API_URL))
 
-	return <Provider value={{ api, setApi }}>{props.children}</Provider>
+	return (
+		<context.Provider value={{ api, setApi }}>
+			{props.children}
+		</context.Provider>
+	)
 }
 
-export { ApiContextProvider, Consumer as ApiContextConsumer }
+export { context as ApiContext, ApiContextProvider, ApiContextConsumer }

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,7 +1,7 @@
 import { Container } from '@material-ui/core'
 import React from 'react'
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
-import { ApiContextConsumer, ApiContextProvider } from '../ApiContext'
+import { ApiContextProvider } from '../ApiContext'
 import { AppTitleContextProvider } from '../AppTitleContext'
 import { ConfigPage } from '../ConfigPage/ConfigPage'
 import { Footer } from '../Footer/Footer'
@@ -31,9 +31,7 @@ function App() {
 								<IconDemo />
 							</Route>
 							<Route path="/search-users" exact>
-								<ApiContextConsumer>
-									{({ api }) => <SearchUsersPage api={api} />}
-								</ApiContextConsumer>
+								<SearchUsersPage />
 							</Route>
 							<Route path="/">
 								<PageNotFoundPage />

--- a/src/Nav/Nav.tsx
+++ b/src/Nav/Nav.tsx
@@ -9,8 +9,8 @@ import {
 	Typography,
 } from '@material-ui/core'
 import MenuIcon from '@material-ui/icons/Menu'
-import React, { FC, MouseEvent, useState } from 'react'
-import { AppTitleContextConsumer } from '../AppTitleContext'
+import React, { FC, MouseEvent, useContext, useState } from 'react'
+import { AppTitleContext } from '../AppTitleContext'
 
 const useStyles = makeStyles((theme) => ({
 	menuButton: {
@@ -38,6 +38,8 @@ const Nav: FC = () => {
 		setMenuIsOpen(false)
 		setAnchorElem(null)
 	}
+
+	const { title } = useContext(AppTitleContext)
 
 	return (
 		<div className={classes.root}>
@@ -114,13 +116,10 @@ const Nav: FC = () => {
 						</MenuItem>
 					</Menu>
 					<Typography
-						variant="h4"
-						component="h1"
 						className={classes.title}
+						variant="h4"
 					>
-						<AppTitleContextConsumer>
-							{(context) => context.title}
-						</AppTitleContextConsumer>
+						{title}
 					</Typography>
 				</Toolbar>
 			</AppBar>

--- a/src/SearchUsersPage/SearchUsersPage.tsx
+++ b/src/SearchUsersPage/SearchUsersPage.tsx
@@ -7,15 +7,16 @@ import {
 	Typography,
 } from '@material-ui/core'
 import React, { FC, useContext, useEffect, useState } from 'react'
+import { ApiContext } from '../ApiContext'
 import { AppTitleContext } from '../AppTitleContext'
 import { ApiService } from '../services/ApiService'
 import { theme } from '../theme'
 import './SearchUsersPage.css'
 
 interface SearchUsersPageProps {
-	api: ApiService
 	initialSearchValue?: string
 	userSearchFunc?: (
+		api: ApiService,
 		searchKey: string,
 		updateFunc: (updatedResult: any) => void
 	) => Promise<void>
@@ -34,9 +35,9 @@ const useStyles = makeStyles({
 })
 
 const SearchUsersPage: FC<SearchUsersPageProps> = ({
-	api,
 	initialSearchValue = '',
 	userSearchFunc = async (
+		api: ApiService,
 		searchKey: string,
 		updateFunc: (updatedResult: any) => void
 	) => {
@@ -63,6 +64,7 @@ const SearchUsersPage: FC<SearchUsersPageProps> = ({
 
 	const classes = useStyles(theme)
 
+	const { api } = useContext(ApiContext)
 	const context = useContext(AppTitleContext)
 
 	useEffect(() => {
@@ -94,7 +96,7 @@ const SearchUsersPage: FC<SearchUsersPageProps> = ({
 							if (e.key !== 'Enter') {
 								return
 							}
-							userSearchFunc(searchValue, setResult).then(() => {
+							userSearchFunc(api, searchValue, setResult).then(() => {
 								setHasSearched(true)
 							})
 						}}
@@ -106,7 +108,7 @@ const SearchUsersPage: FC<SearchUsersPageProps> = ({
 					<Button
 						color="primary"
 						onClick={() => {
-							userSearchFunc(searchValue, setResult).then(() => {
+							userSearchFunc(api, searchValue, setResult).then(() => {
 								setHasSearched(true)
 							})
 						}}


### PR DESCRIPTION
## Description

This change removes the `api` prop from the SearchUsersPage in favor of using the `ApiContext`. It closes #36 

## Screenshot(s) (if applicable, e.g. style updates)

n/a

## PR Readiness Checklist

* General
    * [x] Verified all changes are related to feature described above (no scope creep)
* Branch Stuff
    * [x] Checked target and base branch (should be feature branch merging INTO `main`)
    * [x] Merged latest `main` into feature branch (so it has latest code)
    * [x] Resolved any conflicts between feature branch and `main`
* Test Stuff
    * [x] Added unit tests to cover modified / additional code
* GitHub Stuff (on the right 👉)
    * [x] Updated labels
    * [x] Linked issue to which this PR relates
    * [x] Added assignee
    * [x] Added at least one (1) reviewer
