### PR TITLE
DisplayUsersPageCrashing#69

### DIFF
--- a/src/DisplayUsersPage/DisplayUsersPage.test.tsx
+++ b/src/DisplayUsersPage/DisplayUsersPage.test.tsx
@@ -18,6 +18,7 @@ describe('DisplayUsersPage component', () => {
 				name: fakeUsername,
 				profileIconId: fakeIconId,
 				summonerLevel: fakeLevel,
+				lastUpdated: new Date(1, 1, 2022),
 			},
 		])
 

--- a/src/DisplayUsersPage/DisplayUsersPage.tsx
+++ b/src/DisplayUsersPage/DisplayUsersPage.tsx
@@ -139,7 +139,9 @@ const DisplayUsersPage: FC = () => {
 									color="secondary"
 									variant="h6"
 								>
-									{dateFormatMed.format(lastUpdated)}
+									{dateFormatMed.format(
+										Date.parse(lastUpdated)
+									)}
 								</Typography>
 							</ListItem>
 						</List>

--- a/src/types/IUser.ts
+++ b/src/types/IUser.ts
@@ -1,6 +1,6 @@
 export interface IUser {
 	accountId: string
-	lastUpdated: number
+	lastUpdated: string
 	masteryTotal: number
 	name: string
 	summonerId: string


### PR DESCRIPTION
Crash was caused when date was returned as a string not a num or date.
Updated IUser lastChanged value to string and parsed string in DisplayUsers

Nice

## PR Readiness Checklist

<!-- Replace [ ] with [x] (brackets w/ lowercase x between them, no spaces) as each item is completed -->

* General
    * [x] Verified all changes are related to feature described above (no scope creep)
* Branch Stuff
    * [x] Checked target and base branch (should be feature branch merging INTO `main`)
    * [x] Merged latest `main` into feature branch (so it has latest code)
    * [x] Resolved any conflicts between feature branch and `main`
* Test Stuff
    * [ ] Added unit tests to cover modified / additional code
* GitHub Stuff (on the right 👉)
    * [x] Updated labels
    * [x] Linked issue to which this PR relates
    * [x] Added assignee
    * [x] Added at least one (1) reviewer
